### PR TITLE
Feat custom errors - abstraction and standardization erros

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,0 +1,27 @@
+import { InternalServerError, MethodNotAllowedError } from "./errors";
+
+function onNoMatchHandler(_, res) {
+  const publicErrorObject = new MethodNotAllowedError();
+
+  res.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+function onErrorHandler(error, _, res) {
+  const publicErrorObject = new InternalServerError({
+    statusCode: error.statusCode,
+    cause: error,
+  });
+
+  console.error(publicErrorObject);
+
+  res.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+const controller = {
+  errorHandlers: {
+    onNoMatch: onNoMatchHandler,
+    onError: onErrorHandler,
+  },
+};
+
+export default controller;

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,5 +1,7 @@
 import { Client } from "pg";
 
+import { ServiceError } from "./errors";
+
 function getSSLValue() {
   if (process.env.POSTGRES_CA) {
     return {
@@ -33,9 +35,15 @@ async function query(queryObject) {
 
     return result;
   } catch (error) {
-    console.log("\n Error no cath do database.js:");
-    console.log(error);
-    throw error;
+    const serviceErrorObject = new ServiceError({
+      message: "Error na conexão com Banco dados ou na Query.",
+      cause: error,
+    });
+    // name: "",
+    // action: "",
+    // statusCode: 405,
+
+    throw serviceErrorObject;
   } finally {
     await client?.end();
   }

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,11 +1,11 @@
 export class InternalServerError extends Error {
-  constructor({ cause }) {
+  constructor({ cause, statusCode }) {
     super("Um erro interno não esperado aconteceu.", {
       cause,
     });
     this.name = "InternalServerError";
     this.action = "Entre em contato com suporte.";
-    this.statusCode = 500;
+    this.statusCode = statusCode || 500;
   }
   //Defining what returns in the custom error list
   //Definindo o que retorna na lista de erros customizados
@@ -25,6 +25,27 @@ export class MethodNotAllowedError extends Error {
     this.name = "MethodNotAllowedError";
     this.action = "Verifique se o método HTTP é válido para este endpoint.";
     this.statusCode = 405;
+  }
+  //Defining what returns in the custom error list
+  //Definindo o que retorna na lista de erros customizados
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class ServiceError extends Error {
+  constructor({ cause, message }) {
+    super(message || "Serviço indisponível no momento.", {
+      cause,
+    });
+    this.name = "ServiceError";
+    this.action = "Verifique se o serviço está disponível.";
+    this.statusCode = 503;
   }
   //Defining what returns in the custom error list
   //Definindo o que retorna na lista de erros customizados

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -18,3 +18,22 @@ export class InternalServerError extends Error {
     };
   }
 }
+
+export class MethodNotAllowedError extends Error {
+  constructor() {
+    super("Método não permitido para este endpoint.");
+    this.name = "MethodNotAllowedError";
+    this.action = "Verifique se o método HTTP é válido para este endpoint.";
+    this.statusCode = 405;
+  }
+  //Defining what returns in the custom error list
+  //Definindo o que retorna na lista de erros customizados
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "16.4.5",
         "dotenv-expand": "11.0.6",
         "next": "15.0.2",
+        "next-connect": "1.0.0",
         "node-pg-migrate": "7.7.1",
         "pg": "8.13.1",
         "react": "18.3.1",
@@ -2453,6 +2454,12 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -8851,6 +8858,19 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9947,6 +9967,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/remove": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dotenv": "16.4.5",
     "dotenv-expand": "11.0.6",
     "next": "15.0.2",
+    "next-connect": "1.0.0",
     "node-pg-migrate": "7.7.1",
     "pg": "8.13.1",
     "react": "18.3.1",

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,51 +1,60 @@
-import database from "infra/database.js";
+import { createRouter } from "next-connect";
 import migrationRunner from "node-pg-migrate";
 import { resolve } from "node:path";
 
-export default async function migrations(req, res) {
-  const allowedMethods = ["GET", "POST"];
+import database from "infra/database.js";
+import controller from "infra/controller.js";
 
-  if (!allowedMethods.includes(req.method)) {
-    return res.status(405).json({
-      error: `Method "${req.method}" not allowed`,
-    });
-  }
+const router = createRouter();
 
+router.get(getHandler);
+router.post(postHandler);
+
+export default router.handler(controller.errorHandlers);
+
+const defaultMigrationOptions = {
+  dir: resolve("infra", "migrations"),
+  migrationsTable: "pgmigrations",
+  direction: "up",
+  dryRun: true,
+  verbose: true,
+};
+
+async function getHandler(_, res) {
   let dbClient;
 
   try {
     dbClient = await database.getNewClient();
 
-    const defaultMigrationOptions = {
-      dbClient: dbClient,
-      dir: resolve("infra", "migrations"),
-      migrationsTable: "pgmigrations",
-      direction: "up",
+    const pendingMigrations = await migrationRunner({
+      ...defaultMigrationOptions,
+      dbClient,
       dryRun: true,
-      verbose: true,
-    };
+    });
 
-    if (req.method === "GET") {
-      const pendingMigrations = await migrationRunner(defaultMigrationOptions);
+    return res.status(200).json(pendingMigrations);
+  } finally {
+    await dbClient.end();
+  }
+}
 
-      return res.status(200).json(pendingMigrations);
+async function postHandler(_, res) {
+  let dbClient;
+
+  try {
+    dbClient = await database.getNewClient();
+
+    const migratedMigrations = await migrationRunner({
+      ...defaultMigrationOptions,
+      dbClient,
+      dryRun: false,
+    });
+
+    if (migratedMigrations.length > 0) {
+      return res.status(201).json(migratedMigrations);
     }
 
-    if (req.method === "POST") {
-      const migratedMigrations = await migrationRunner({
-        ...defaultMigrationOptions,
-        dryRun: false,
-      });
-
-      if (migratedMigrations.length > 0) {
-        return res.status(201).json(migratedMigrations);
-      }
-
-      return res.status(200).json(migratedMigrations);
-    }
-  } catch (error) {
-    console.log(error);
-    throw error;
+    return res.status(200).json(migratedMigrations);
   } finally {
     await dbClient.end();
   }

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,32 +1,13 @@
 import { createRouter } from "next-connect";
 
 import database from "infra/database.js";
-import { InternalServerError, MethodNotAllowedError } from "infra/errors";
+import controller from "infra/controller.js";
 
 const router = createRouter();
 
 router.get(getHandler);
 
-export default router.handler({
-  onNoMatch: onNoMatchHandler,
-  onError: onErrorHandler,
-});
-
-function onNoMatchHandler(_, res) {
-  const publicErrorObject = new MethodNotAllowedError();
-
-  res.status(publicErrorObject.statusCode).json(publicErrorObject);
-}
-
-function onErrorHandler(error, _, res) {
-  const publicErrorObject = new InternalServerError({
-    cause: error,
-  });
-  console.log("\n Error no cath do next-connect:");
-  console.log(publicErrorObject);
-
-  res.status(500).json(publicErrorObject);
-}
+export default router.handler(controller.errorHandlers);
 
 async function getHandler(_, res) {
   const updateAt = new Date().toISOString();

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,85 +1,64 @@
+import { createRouter } from "next-connect";
+
 import database from "infra/database.js";
-import { InternalServerError } from "infra/errors";
-/* TESTES V1
-async function status(req, res) {
-  const result = await database.query("SELECT 1 + 1 as sum;");
+import { InternalServerError, MethodNotAllowedError } from "infra/errors";
 
-  console.log(result.rows);
+const router = createRouter();
 
-  res.status(200).json({ message: "API de STATUS" });
-}*/
+router.get(getHandler);
 
-async function status(req, res) {
-  try {
-    const updateAt = new Date().toISOString();
-    const databaseVersionResult = await database.query("SHOW server_version;");
-    const databaseVersionValue =
-      databaseVersionResult.rows[0].server_version.split(" ")[0];
+export default router.handler({
+  onNoMatch: onNoMatchHandler,
+  onError: onErrorHandler,
+});
 
-    const databaseMaxConnectionResult = await database.query(
-      "SHOW max_connections",
-    );
-    const databaseMaxConnectionValue = parseInt(
-      databaseMaxConnectionResult.rows[0].max_connections,
-    );
+function onNoMatchHandler(_, res) {
+  const publicErrorObject = new MethodNotAllowedError();
 
-    const databaseName = process.env.POSTGRES_DB;
-
-    /* SEM TRATATIVA DE SQL Injection
-    const databaseOpenConnectionsResult = await database.query(
-      `SELECT count(*)::int from pg_stat_activity WHERE datname = '${databaseName}';`
-    );*/
-
-    /* COM TRATATIVA DE SQL Injection*/
-    const databaseOpenConnectionsResult = await database.query({
-      text: `SELECT count(*)::int from pg_stat_activity WHERE datname = $1;`,
-      values: [databaseName],
-    });
-    const databaseOpenConnectionsValue = parseInt(
-      databaseOpenConnectionsResult.rows[0].count,
-    );
-
-    /**INICIO - TESTE Sql Injection */
-
-    //const requestDatabaseName = req.query.databaseName;
-
-    /*const resquestDatabaseOpenConnectionsResult = await database.query(
-      `SELECT count(*)::int from pg_stat_activity WHERE datname = '${requestDatabaseName}';`
-    );*/
-
-    /**TESTE Sql Injection - Sanitização (Resolução)*/
-    /*
-    const resquestDatabaseOpenConnectionsResultSanitizacao =
-      await database.query({
-        text: `SELECT count(*)::int from pg_stat_activity WHERE datname = $1;`,
-        values: [requestDatabaseName],
-      });
-    console.log(resquestDatabaseOpenConnectionsResultSanitizacao.rows);
-    */
-    /**FIM - TESTE Sql Injection */
-
-    //console.log(databaseOpenConnectionsValue);
-
-    res.status(200).json({
-      update_at: updateAt,
-      dependencies: {
-        database: {
-          version: databaseVersionValue,
-          max_connections: databaseMaxConnectionValue,
-          opened_connections: databaseOpenConnectionsValue,
-        },
-      },
-    });
-  } catch (error) {
-    const publicErrorObject = new InternalServerError({
-      cause: error,
-    });
-    console.log("\n Error no cath do controller:");
-    console.log(publicErrorObject);
-    //console.log(error);
-
-    res.status(500).json(publicErrorObject);
-  }
+  res.status(publicErrorObject.statusCode).json(publicErrorObject);
 }
 
-export default status;
+function onErrorHandler(error, _, res) {
+  const publicErrorObject = new InternalServerError({
+    cause: error,
+  });
+  console.log("\n Error no cath do next-connect:");
+  console.log(publicErrorObject);
+
+  res.status(500).json(publicErrorObject);
+}
+
+async function getHandler(_, res) {
+  const updateAt = new Date().toISOString();
+  const databaseVersionResult = await database.query("SHOW server_version;");
+  const databaseVersionValue =
+    databaseVersionResult.rows[0].server_version.split(" ")[0];
+
+  const databaseMaxConnectionResult = await database.query(
+    "SHOW max_connections",
+  );
+  const databaseMaxConnectionValue = parseInt(
+    databaseMaxConnectionResult.rows[0].max_connections,
+  );
+
+  const databaseName = process.env.POSTGRES_DB;
+
+  const databaseOpenConnectionsResult = await database.query({
+    text: `SELECT count(*)::int from pg_stat_activity WHERE datname = $1;`,
+    values: [databaseName],
+  });
+  const databaseOpenConnectionsValue = parseInt(
+    databaseOpenConnectionsResult.rows[0].count,
+  );
+
+  res.status(200).json({
+    update_at: updateAt,
+    dependencies: {
+      database: {
+        version: databaseVersionValue,
+        max_connections: databaseMaxConnectionValue,
+        opened_connections: databaseOpenConnectionsValue,
+      },
+    },
+  });
+}

--- a/tests/integration/api/v1/status/get.test.js
+++ b/tests/integration/api/v1/status/get.test.js
@@ -24,17 +24,3 @@ describe("GET to /api/v1/status", () => {
     });
   });
 });
-/*test.only("Teste de SQL Injection", async () => {
-  const response = await fetch(
-    "http://localhost:3000/api/v1/status?databaseName=local_db"
-  );
-  await fetch(
-    "http://localhost:3000/api/v1/status?databaseName='; SELECT pg_sleep(4); --"
-  );
-});*/
-/*
-test.only("Teste de SQL Injection - Sanitização", async () => {
-  await fetch(
-    "http://localhost:3000/api/v1/status?databaseName='; SELECT pg_sleep(4); --"
-  );
-});*/

--- a/tests/integration/api/v1/status/post.test.js
+++ b/tests/integration/api/v1/status/post.test.js
@@ -1,0 +1,25 @@
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+
+describe("POST to /api/v1/status", () => {
+  describe("Anonymous user", () => {
+    test("Retrieving current system status", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/status", {
+        method: "POST",
+      });
+      expect(response.status).toBe(405);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método não permitido para este endpoint.",
+        action: "Verifique se o método HTTP é válido para este endpoint.",
+        status_code: 405,
+      });
+    });
+  });
+});


### PR DESCRIPTION
1. Padroniza os Controllers dos endpoints `/migrations` e `/status `
2. Adiciona dois novos erros customizados: `MethodNotAllowedError` e `ServiceError`
3. Faz o `InternalServerError` aceitar injeção do `statusCode`