### PR TITLE
feat:  create user model

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -2,6 +2,7 @@ import {
   InternalServerError,
   MethodNotAllowedError,
   ValidationError,
+  NotFoundError,
 } from "./errors";
 
 function onNoMatchHandler(_, res) {
@@ -11,7 +12,7 @@ function onNoMatchHandler(_, res) {
 }
 
 function onErrorHandler(error, _, res) {
-  if (error instanceof ValidationError) {
+  if (error instanceof ValidationError || error instanceof NotFoundError) {
     return res.status(error.statusCode).json(error);
   }
 

--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,4 +1,8 @@
-import { InternalServerError, MethodNotAllowedError } from "./errors";
+import {
+  InternalServerError,
+  MethodNotAllowedError,
+  ValidationError,
+} from "./errors";
 
 function onNoMatchHandler(_, res) {
   const publicErrorObject = new MethodNotAllowedError();
@@ -7,6 +11,10 @@ function onNoMatchHandler(_, res) {
 }
 
 function onErrorHandler(error, _, res) {
+  if (error instanceof ValidationError) {
+    return res.status(error.statusCode).json(error);
+  }
+
   const publicErrorObject = new InternalServerError({
     statusCode: error.statusCode,
     cause: error,

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -26,8 +26,25 @@ export class MethodNotAllowedError extends Error {
     this.action = "Verifique se o método HTTP é válido para este endpoint.";
     this.statusCode = 405;
   }
-  //Defining what returns in the custom error list
-  //Definindo o que retorna na lista de erros customizados
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class ValidationError extends Error {
+  constructor({ cause, message, action }) {
+    super(message || "Um error de validação ocorreu.", {
+      cause,
+    });
+    this.name = "ValidationError";
+    this.action = action || "Ajuste os dados enviados e tente novamente.";
+    this.statusCode = 400;
+  }
   toJSON() {
     return {
       name: this.name,
@@ -47,8 +64,6 @@ export class ServiceError extends Error {
     this.action = "Verifique se o serviço está disponível.";
     this.statusCode = 503;
   }
-  //Defining what returns in the custom error list
-  //Definindo o que retorna na lista de erros customizados
   toJSON() {
     return {
       name: this.name,

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -55,6 +55,27 @@ export class ValidationError extends Error {
   }
 }
 
+export class NotFoundError extends Error {
+  constructor({ cause, message, action }) {
+    super(message || "Recurso não encontrado no sistema.", {
+      cause,
+    });
+    this.name = "NotFoundError";
+    this.action =
+      action ||
+      "Verifique os parâmetros enviados na consulta estão correto e tente novamente.";
+    this.statusCode = 404;
+  }
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
 export class ServiceError extends Error {
   constructor({ cause, message }) {
     super(message || "Serviço indisponível no momento.", {

--- a/infra/migrations/1730168388865_migration-test.js
+++ b/infra/migrations/1730168388865_migration-test.js
@@ -1,8 +1,0 @@
-/* eslint-disable no-unused-vars */
-/* eslint-disable camelcase */
-
-exports.shorthands = undefined;
-
-exports.up = (pgm) => {};
-
-exports.down = (pgm) => {};

--- a/infra/migrations/1755826023708_create-users.js
+++ b/infra/migrations/1755826023708_create-users.js
@@ -1,0 +1,58 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+exports.shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.up = (pgm) => {
+  pgm.createTable("users", {
+    id: {
+      type: "uuid",
+      primaryKey: true,
+      default: pgm.func("gen_random_uuid()"),
+    },
+    // For reference, Github limits usernames to 39 caracteres.
+    username: {
+      type: "varchar(30)",
+      notNull: true,
+      unique: true,
+    },
+    // Why 254 in length?
+    // reference: https://stackoverflow.com/a/1199238
+    email: {
+      type: "varchar(254)",
+      notNull: true,
+      unique: true,
+    },
+    // Why 60 in length?
+    // reference: https://security.stackexchange.com/a/184090
+    // reference: https://www.npmjs.com/package/bcrypt#hash-info
+    password: {
+      type: "varchar(60)",
+      notNull: true,
+    },
+    // Why timestamp with timezone?
+    // reference: https://justatheory.com/2012/04/postgres-use-timestamptz
+    created_at: {
+      type: "timestamptz", //TimeZone
+      default: pgm.func("timezone('utc', now())"),
+      notNull: true,
+    },
+    updated_at: {
+      type: "timestamptz", //TimeZone
+      default: pgm.func("timezone('utc', now())"),
+      notNull: true,
+    },
+  });
+};
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.down = false;

--- a/models/migrator.js
+++ b/models/migrator.js
@@ -8,7 +8,8 @@ const defaultMigrationOptions = {
   migrationsTable: "pgmigrations",
   direction: "up",
   dryRun: true,
-  verbose: true,
+  //verbose: true,
+  log: () => {}, //Oculta os logs
 };
 
 async function listPendingMigrations() {

--- a/models/user.js
+++ b/models/user.js
@@ -1,0 +1,82 @@
+import database from "infra/database";
+import { ValidationError } from "infra/errors";
+
+async function runInsertQuery(userInputValues) {
+  //implementação e insert
+  const result = await database.query({
+    text: `
+          INSERT INTO 
+            users (username, email, password) 
+          VALUES 
+            ($1, $2, $3)
+          RETURNING
+            *
+          ;
+          `,
+    values: [
+      userInputValues.username,
+      userInputValues.email,
+      userInputValues.password,
+    ],
+  });
+
+  return result.rows[0];
+}
+
+async function validateUniqueEmail(email) {
+  const result = await database.query({
+    text: `
+          SELECT email
+          FROM
+            users 
+          WHERE 
+            LOWER(email) = LOWER($1)
+          ;
+          `,
+    values: [email],
+  });
+
+  if (result.rowCount > 0) {
+    throw new ValidationError({
+      message: "O email informado já está cadastrado.",
+      action: "Informe outro email para realizar o cadastro.",
+    });
+  }
+}
+
+async function validateUniqueUsername(username) {
+  const result = await database.query({
+    text: `
+          SELECT username
+          FROM
+            users 
+          WHERE 
+            LOWER(username) = LOWER($1)
+          ;
+          `,
+    values: [username],
+  });
+
+  if (result.rowCount > 0) {
+    throw new ValidationError({
+      message: "O username informado já está cadastrado.",
+      action: "Informe outro username para realizar o cadastro.",
+    });
+  }
+}
+
+async function create(userInputValues) {
+  //regras de negocio
+  await validateUniqueEmail(userInputValues.email);
+  await validateUniqueUsername(userInputValues.username);
+
+  const newUser = await runInsertQuery(userInputValues);
+
+  return newUser;
+}
+
+const user = {
+  create,
+};
+
+export default user;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "remove": "0.1.5",
-        "swr": "2.2.5"
+        "swr": "2.2.5",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@commitlint/cli": "19.5.0",
@@ -11205,6 +11206,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clone-tabnews",
   "version": "1.0.0",
-  "description": "Projeto clone tabnews filipe deshamps para estudo acadêmico do curso.dev",
+  "description": "Projeto clone tabnews filipe deschamps para estudo acadêmico do curso.dev",
   "main": "index.js",
   "scripts": {
     "predev": "",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "remove": "0.1.5",
-    "swr": "2.2.5"
+    "swr": "2.2.5",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "19.5.0",

--- a/pages/api/v1/users/[username]/index.js
+++ b/pages/api/v1/users/[username]/index.js
@@ -1,0 +1,18 @@
+import { createRouter } from "next-connect";
+
+import controller from "infra/controller.js";
+import user from "models/user.js";
+
+const router = createRouter();
+
+router.get(getHandler);
+
+export default router.handler(controller.errorHandlers);
+
+async function getHandler(req, res) {
+  const username = req.query.username;
+
+  const userFound = await user.findOneByUserName(username);
+
+  return res.status(200).json(userFound);
+}

--- a/pages/api/v1/users/index.js
+++ b/pages/api/v1/users/index.js
@@ -1,0 +1,18 @@
+import { createRouter } from "next-connect";
+
+import controller from "infra/controller.js";
+import user from "models/user.js";
+
+const router = createRouter();
+
+router.post(postHandler);
+
+export default router.handler(controller.errorHandlers);
+
+async function postHandler(req, res) {
+  const userInputValues = req.body;
+
+  const newUser = await user.create(userInputValues);
+
+  return res.status(201).json(newUser);
+}

--- a/tests/integration/api/v1/users/[username]/get.test.js
+++ b/tests/integration/api/v1/users/[username]/get.test.js
@@ -1,0 +1,106 @@
+import { version as uuidVersion } from "uuid";
+
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabase();
+  await orchestrator.runPendingMigrations();
+});
+
+describe("GET to /api/v1/users/[username]", () => {
+  describe("Anonymous user", () => {
+    test("With exact case match 'username'", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "MesmoCase",
+          email: "mesmo.case@email.com.br",
+          password: "senha123",
+        }),
+      });
+
+      expect(response1.status).toBe(201);
+
+      const response2 = await fetch(
+        "http://localhost:3000/api/v1/users/MesmoCase",
+      );
+
+      expect(response2.status).toBe(200);
+
+      const response2Body = await response2.json();
+
+      expect(response2Body).toEqual({
+        id: response2Body.id,
+        username: "MesmoCase",
+        email: "mesmo.case@email.com.br",
+        password: "senha123",
+        created_at: response2Body.created_at,
+        updated_at: response2Body.updated_at,
+      });
+
+      const versionUUID = 4;
+      expect(uuidVersion(response2Body.id)).toBe(versionUUID);
+      expect(Date.parse(response2Body.created_at)).not.toBeNaN();
+      expect(Date.parse(response2Body.updated_at)).not.toBeNaN();
+    });
+
+    test("With case mismatch 'username'", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "CaseDiferente",
+          email: "case.diferente@email.com.br",
+          password: "senha123",
+        }),
+      });
+
+      expect(response1.status).toBe(201);
+
+      const response2 = await fetch(
+        "http://localhost:3000/api/v1/users/caseDiferente",
+      );
+
+      expect(response2.status).toBe(200);
+
+      const response2Body = await response2.json();
+
+      expect(response2Body).toEqual({
+        id: response2Body.id,
+        username: "CaseDiferente",
+        email: "case.diferente@email.com.br",
+        password: "senha123",
+        created_at: response2Body.created_at,
+        updated_at: response2Body.updated_at,
+      });
+
+      const versionUUID = 4;
+      expect(uuidVersion(response2Body.id)).toBe(versionUUID);
+      expect(Date.parse(response2Body.created_at)).not.toBeNaN();
+      expect(Date.parse(response2Body.updated_at)).not.toBeNaN();
+    });
+
+    test("With nonexistent 'username'", async () => {
+      const response = await fetch(
+        "http://localhost:3000/api/v1/users/usuariosemcadastro",
+      );
+
+      expect(response.status).toBe(404);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "NotFoundError",
+        message: "O usuário informado sem cadastro.",
+        action: "Informe corretamente username para realizar busca.",
+        status_code: 404,
+      });
+    });
+  });
+});

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -1,0 +1,37 @@
+import database from "infra/database";
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabase();
+  await orchestrator.runPendingMigrations();
+});
+
+describe("POST to /api/v1/users", () => {
+  describe("Anonymous user", () => {
+    test("With unique and valid data", async () => {
+      await database.query({
+        text: "INSERT INTO users (username, email, password) VALUES ($1, $2, $3);",
+        values: [
+          "josuellopes",
+          "josuellopes@email, password.com.br",
+          "senha123",
+        ],
+      });
+
+      // await database.query({
+      //   text: "INSERT INTO users (username, email) VALUES ($1, $2, $3);",
+      //   values: ["josuelalves", "Josuellopes@email.com.br", "senha123"],
+      // });
+
+      const users = await database.query("SELECT * FROM users;");
+
+      console.info(">>TEST USERS");
+      console.log(users.rows);
+      const response = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+      });
+      expect(response.status).toBe(201);
+    });
+  });
+});

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -1,4 +1,5 @@
-import database from "infra/database";
+import { version as uuidVersion } from "uuid";
+
 import orchestrator from "tests/orchestrator";
 
 beforeAll(async () => {
@@ -10,28 +11,113 @@ beforeAll(async () => {
 describe("POST to /api/v1/users", () => {
   describe("Anonymous user", () => {
     test("With unique and valid data", async () => {
-      await database.query({
-        text: "INSERT INTO users (username, email, password) VALUES ($1, $2, $3);",
-        values: [
-          "josuellopes",
-          "josuellopes@email, password.com.br",
-          "senha123",
-        ],
-      });
-
-      // await database.query({
-      //   text: "INSERT INTO users (username, email) VALUES ($1, $2, $3);",
-      //   values: ["josuelalves", "Josuellopes@email.com.br", "senha123"],
-      // });
-
-      const users = await database.query("SELECT * FROM users;");
-
-      console.info(">>TEST USERS");
-      console.log(users.rows);
       const response = await fetch("http://localhost:3000/api/v1/users", {
         method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "josuellopes",
+          email: "josuellopes@email.com.br",
+          password: "senha123",
+        }),
       });
+
       expect(response.status).toBe(201);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        id: responseBody.id,
+        username: "josuellopes",
+        email: "josuellopes@email.com.br",
+        password: "senha123",
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+      });
+
+      const versionUUID = 4;
+      expect(uuidVersion(responseBody.id)).toBe(versionUUID);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+    });
+
+    test("With duplicated 'email'", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "emailduplicado",
+          email: "emailduplicado@email.com.br",
+          password: "senha123",
+        }),
+      });
+
+      expect(response1.status).toBe(201);
+
+      const response2 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "emailduplicado2",
+          email: "EmailDuplicado@email.com.br",
+          password: "senha123",
+        }),
+      });
+
+      expect(response2.status).toBe(400);
+
+      const response2Body = await response2.json();
+
+      expect(response2Body).toEqual({
+        name: "ValidationError",
+        message: "O email informado já está cadastrado.",
+        action: "Informe outro email para realizar o cadastro.",
+        status_code: 400,
+      });
+    });
+
+    test("With duplicated 'username'", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "usernameduplicado",
+          email: "usernameduplicado1@email.com.br",
+          password: "senha123",
+        }),
+      });
+
+      expect(response1.status).toBe(201);
+
+      const response2 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "UsernameDuplicado",
+          email: "usernameduplicado2@email.com.br",
+          password: "senha123",
+        }),
+      });
+
+      expect(response2.status).toBe(400);
+
+      const response2Body = await response2.json();
+
+      expect(response2Body).toEqual({
+        name: "ValidationError",
+        message: "O username informado já está cadastrado.",
+        action: "Informe outro username para realizar o cadastro.",
+        status_code: 400,
+      });
     });
   });
 });

--- a/tests/orchestrator.ts
+++ b/tests/orchestrator.ts
@@ -1,5 +1,6 @@
 import retry from "async-retry";
 import database from "infra/database";
+import migrator from "models/migrator";
 
 const STATUS_SUCCESS = 200;
 
@@ -30,7 +31,12 @@ async function clearDatabase() {
   await database.query("drop schema public cascade; create schema public;");
 }
 
+async function runPendingMigrations() {
+  await migrator.runPendingMigrations();
+}
+
 const orchestrator = {
+  runPendingMigrations,
   waitForAllServices,
   clearDatabase,
 };


### PR DESCRIPTION
- Cria modelo `user`
- Cria dois novos endpoints:
  - `POST` in `/api/v1/users`
  - `GET` in `/api/v1/users/[username]`
- Remove `migration` de teste
- Cria `migration` que cria a tabela `users`
- Cria dois novos erros customizados:
  - `ValidationError`
  - `NotFoundError`  
- Adiciona novo método ao `orchestrator`:
  - `runPendingMigrations`
- Silencia os logs do `migrator`   